### PR TITLE
Added hyperscale server type for nodes

### DIFF
--- a/ansible/create-clc-hosts.yml
+++ b/ansible/create-clc-hosts.yml
@@ -75,6 +75,16 @@
         async_poll: 10
       when: server_type == "bareMetal"
 
+    - name: Set anti-affinity policy if type = hyperscale
+      set_fact:
+        anti_affinity_name: "{{ anti_affinity_name }}"
+      when: server_type == "hyperscale"
+
+    - name: Set correct storage type if server type = hyperscale
+      set_fact:
+        storage_type: "hyperscale"
+      when: server_type == "hyperscale"
+
   roles:
     - { role: clc-provisioning, when: skip_minion == False }
 

--- a/ansible/create-minion-hosts.yml
+++ b/ansible/create-minion-hosts.yml
@@ -40,11 +40,29 @@
             type: partitioned
       when: server_type == "standard" and server_storage > 0
 
+    - name: Allocate additional_disks /data space on virtual ("hyperscale") minions
+      set_fact:
+        server_additional_disks:
+          - path: /data
+            sizeGB: "{{ server_storage }}"
+            type: partitioned
+      when: server_type == "hyperscale" and server_storage > 0
+
     - name: Set Async time differently if type = bareMetal
       set_fact:
         async_time: 14400
         async_poll: 10
       when: server_type == "bareMetal"
+
+    - name: Set anti-affinity policy if type = hyperscale
+      set_fact:
+        anti_affinity_name: "{{ anti_affinity_name }}"
+      when: server_type == "hyperscale"
+
+    - name: Set correct storage type if server type = hyperscale
+      set_fact:
+        storage_type: "hyperscale"
+      when: server_type == "hyperscale"
 
   roles:
     - { role: clc-provisioning, when: skip_minion == False }

--- a/ansible/roles/clc-provisioning/defaults/main.yml
+++ b/ansible/roles/clc-provisioning/defaults/main.yml
@@ -28,11 +28,13 @@ server_count: 1
 ## options are
 # standard (vm)
 # bareMetal
+# hyperscale
 server_type: standard
 
 ## options are
 # standard (vm)
 # bareMetal
+# hyperscale
 storage_type: standard
 
 ## mount addition filesystem storage

--- a/ansible/roles/clc-provisioning/tasks/main.yml
+++ b/ansible/roles/clc-provisioning/tasks/main.yml
@@ -36,6 +36,7 @@
     storage_type: "{{ storage_type }}"
     configuration_id: "{{ physical_config[server_config_id] }}"
     additional_disks: "{{ server_additional_disks }}"
+    anti_affinity_policy_name: "{{ anti_affinity_name }}"
   register: clc_servers_initial
   async: "{{ async_time }}"
   poll: "{{ async_poll }}"
@@ -66,6 +67,7 @@
     storage_type: "{{ storage_type }}"
     configuration_id: "{{ physical_config[server_config_id] }}"
     additional_disks: "{{ server_additional_disks }}"
+    anti_affinity_policy_name: "{{ anti_affinity_name }}"
   register: clc_servers_additional
   async: "{{ async_time }}"
   poll: "{{ async_poll }}"


### PR DESCRIPTION
I added hyperscale and anti-affinity policy functionality so that Kubernetes nodes could be on different hosts. This would increase the resiliency of the cluster should one of the hosts fail. 
